### PR TITLE
Cdata fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# VSCode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: "3.4"
+python: 
+- "3.4"
+- "3.6"
 # command to install dependencies
 install:
 - "pip install -r requirements.txt"

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Podcast
 -------
 
 * categories (list) A list for strings representing the feed categories
+* atom_link (str): The rss feed hyperlink
 * copyright (string): The feed's copyright
 * creative_commons (string): The feed's creative commons license
 * items (list): A list of Item objects

--- a/pyPodcastParser/Item.py
+++ b/pyPodcastParser/Item.py
@@ -24,6 +24,8 @@ class Item(object):
         enclosure_type (str): File MIME type
         enclosure_length (int): File size in bytes
         guid (str): globally unique identifier
+        itunes_season(str): Podcast season number
+        itunes_episode(str): Podcast episode number
         itunes_author_name (str): Author name given to iTunes
         itunes_block (bool): It this Item blocked from itunes
         itunes_closed_captioned: (str): It is this item have closed captions
@@ -80,6 +82,8 @@ class Item(object):
         item['enclosure_length'] = self.enclosure_length
         item['enclosure_type'] = self.enclosure_type
         item['guid'] = self.guid
+        item['itunes_season'] = self.itunes_season
+        item['itunes_episode'] = self.itunes_episode
         item['itunes_author_name'] = self.itunes_author_name
         item['itunes_block'] = self.itunes_block
         item['itunes_closed_captioned'] = self.itunes_closed_captioned
@@ -193,6 +197,8 @@ class Item(object):
 
     def set_itunes_element(self):
         """Set each of the itunes elements."""
+        self.set_itunes_season()
+        self.set_itunes_episode()
         self.set_itunes_author_name()
         self.set_itunes_block()
         self.set_itunes_closed_captioned()
@@ -202,6 +208,20 @@ class Item(object):
         self.set_itunes_order()
         self.set_itunes_subtitle()
         self.set_itunes_summary()
+
+    def set_itunes_season(self):
+        """Parses season from itunes tags and sets value"""
+        try:
+            self.itunes_season = self.soup.find('itunes:season').string
+        except AttributeError:
+            self.itunes_season = None
+    
+    def set_itunes_episode(self):
+        """Parses episode from itunes tags and sets value"""
+        try:
+            self.itunes_episode = self.soup.find('itunes:episode').string
+        except AttributeError:
+            self.itunes_episode = None
 
     def set_itunes_author_name(self):
         """Parses author name from itunes tags and sets value"""

--- a/pyPodcastParser/Item.py
+++ b/pyPodcastParser/Item.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from datetime import datetime
 import email.utils
 from time import mktime
@@ -139,7 +140,10 @@ class Item(object):
     def set_description(self):
         """Parses description and set value."""
         try:
-            self.description = self.soup.find('description').string
+            desc_text = self.soup.find('description').get_text(strip=True)
+            if ('<' or '>') in desc_text:
+                desc_text = BeautifulSoup(desc_text,'html.parser').get_text(strip=True)
+            self.description = desc_text
         except AttributeError:
             self.description = None
 

--- a/pyPodcastParser/Podcast.py
+++ b/pyPodcastParser/Podcast.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import email.utils
 from time import mktime
+import re
 
 from pyPodcastParser.Item import Item
 
@@ -222,7 +223,7 @@ class Podcast():
     def set_atom_link(self):
         """Parses and set feed atom link href"""
         try:
-            atom_link = self.soup.find('atom:link', attrs={"rel":"self"})
+            atom_link = self.soup.find(re.compile('atom.*:link'), attrs={"rel":"self"})
             if atom_link:
                 self.atom_link = atom_link['href']
             else:

--- a/pyPodcastParser/Podcast.py
+++ b/pyPodcastParser/Podcast.py
@@ -33,6 +33,7 @@ class Podcast():
         image_soup (bs4.BeautifulSoup): soup of image
         full_soup (bs4.BeautifulSoup): A soup of the xml with items
         categories (list): List for strings representing the feed categories
+        atom_link (str): The rss feed hyperlink
         copyright (str): The feed's copyright
         creative_commons (str): The feed's creative commons license
         items (item): Item objects
@@ -119,6 +120,7 @@ class Podcast():
 
     def to_dict(self):
         podcast_dict = {}
+        podcast_dict['atom_link'] = self.atom_link
         podcast_dict['categories'] = self.categories
         podcast_dict['copyright'] = self.copyright
         podcast_dict['creative_commons'] = self.creative_commons
@@ -178,6 +180,7 @@ class Podcast():
 
     def set_optional_elements(self):
         """Sets elements considered option by RSS spec"""
+        self.set_atom_link()
         self.set_categories()
         self.set_copyright()
         self.set_generator()
@@ -216,6 +219,13 @@ class Podcast():
             if item:
                 self.items.append(item)
 
+    def set_atom_link(self):
+        """Parses and set feed atom link href"""
+        try:
+            self.atom_link = self.soup.find('atom:link', attrs={"rel":"self"})['href']
+        except AttributeError:
+            self.atom_link = None
+        
     def set_categories(self):
         """Parses and set feed categories"""
         self.categories = []

--- a/pyPodcastParser/Podcast.py
+++ b/pyPodcastParser/Podcast.py
@@ -248,7 +248,10 @@ class Podcast():
     def set_description(self):
         """Parses description and sets value"""
         try:
-            self.description = self.soup.find('description').string
+            desc_text = self.soup.find('description').get_text(strip=True)
+            if ('<' or '>') in desc_text:
+                desc_text = BeautifulSoup(desc_text,'html.parser').get_text(strip=True)
+            self.description = desc_text
         except AttributeError:
             self.description = None
 

--- a/pyPodcastParser/Podcast.py
+++ b/pyPodcastParser/Podcast.py
@@ -222,7 +222,11 @@ class Podcast():
     def set_atom_link(self):
         """Parses and set feed atom link href"""
         try:
-            self.atom_link = self.soup.find('atom:link', attrs={"rel":"self"})['href']
+            atom_link = self.soup.find('atom:link', attrs={"rel":"self"})
+            if atom_link:
+                self.atom_link = atom_link['href']
+            else:
+                self.atom_link = None
         except AttributeError:
             self.atom_link = None
         

--- a/tests/test_feeds/basic_podcast.rss
+++ b/tests/test_feeds/basic_podcast.rss
@@ -21,6 +21,7 @@
         <atom:link href="https://pubsubhubbub.appspot.com" />
 
         <atom:link rel="hub" href="https://pubsubhubbub.appspot.com" />
+        <atom:link href="https://audioboom.com/channels/5013228.rss" rel="self" type="application/rss+xml" />
 
         <atom:link />
 

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -3,7 +3,7 @@ import datetime
 import os
 import unittest
 
-from pyPodcastParser import Podcast
+from pyPodcastParser.Podcast import Podcast
 
 # py.test test_pyPodcastParser.py
 
@@ -27,7 +27,7 @@ class Test_Valid_RSS_Check(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'itunes_block_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_is_valid_rss(self):
         self.assertEqual(self.podcast.is_valid_rss, True)
@@ -42,7 +42,7 @@ class Test_Invalid_RSS_Check(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'missing_info_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_is_valid_rss(self):
         self.assertEqual(self.podcast.is_valid_rss, False)
@@ -57,7 +57,7 @@ class Test_Basic_Feed_Item_Blocked(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'itunes_block_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_item_itunes_block(self):
         self.assertEqual(self.podcast.itunes_block, True)
@@ -75,7 +75,7 @@ class Test_Basic_Feed_Items(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'basic_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
 
 
@@ -90,9 +90,7 @@ class Test_Basic_Feed_Items(unittest.TestCase):
     def test_item_creative_commons(self):
         self.assertEqual(self.podcast.items[0].creative_commons, "http://www.creativecommons.org/licenses/by-nc/1.0")
         self.assertEqual(self.podcast.items[1].creative_commons, None)
-
-
-
+    
     def test_item_categories(self):
         self.assertTrue("Grateful Dead" in self.podcast.items[0].categories)
         self.assertTrue("Dead and Grateful" in self.podcast.items[1].categories)
@@ -183,7 +181,7 @@ class Test_Basic_Feed(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'basic_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_loding_of_basic_podcast(self):
         self.assertIsNotNone(self.basic_podcast)
@@ -191,6 +189,9 @@ class Test_Basic_Feed(unittest.TestCase):
     def test_dict(self):
         feed_dict = self.podcast.to_dict()
         self.assertTrue(type(feed_dict) is dict)
+
+    def test_atom_link(self):
+        self.assertEqual(self.podcast.atom_link, "https://audioboom.com/channels/5013228.rss")
 
     def test_categories(self):
         self.assertTrue("Example category 2" in self.podcast.categories)
@@ -303,11 +304,13 @@ class Test_Unicode_Feed(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'unicode_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_loding_of_basic_podcast(self):
         self.assertIsNotNone(self.basic_podcast)
 
+    def test_atom_link(self):
+        self.assertIsNone(self.podcast.atom_link)
 
     def test_copyright(self):
         self.assertEqual(self.podcast.copyright, self.unicodeish_text)
@@ -387,11 +390,13 @@ class Test_Missing_Info_Feed(unittest.TestCase):
         basic_podcast_path = os.path.join(test_feeds_dir, 'missing_info_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_loding_of_basic_podcast(self):
         self.assertIsNotNone(self.basic_podcast)
 
+    def test_atom_link(self):
+        self.assertIsNone(self.podcast.atom_link)
 
     def test_categories(self):
         self.assertFalse("Example category 2" in self.podcast.categories)
@@ -506,7 +511,7 @@ class Test_Itunes_Block_Feed(unittest.TestCase):
             test_feeds_dir, 'itunes_block_podcast.rss')
         basic_podcast_file = open(basic_podcast_path, "r")
         self.basic_podcast = basic_podcast_file.read()
-        self.podcast = Podcast.Podcast(self.basic_podcast)
+        self.podcast = Podcast(self.basic_podcast)
 
     def test_itunes_block(self):
         self.assertEqual(self.podcast.itunes_block, True)

--- a/tests/test_pyPodcastParser.py
+++ b/tests/test_pyPodcastParser.py
@@ -91,6 +91,12 @@ class Test_Basic_Feed_Items(unittest.TestCase):
         self.assertEqual(self.podcast.items[0].creative_commons, "http://www.creativecommons.org/licenses/by-nc/1.0")
         self.assertEqual(self.podcast.items[1].creative_commons, None)
     
+    def test_item_itunes_season(self):
+        self.assertIsNone(self.podcast.items[1].itunes_season)
+
+    def test_item_itunes_episode(self):
+        self.assertIsNone(self.podcast.items[1].itunes_episode)  
+
     def test_item_categories(self):
         self.assertTrue("Grateful Dead" in self.podcast.items[0].categories)
         self.assertTrue("Dead and Grateful" in self.podcast.items[1].categories)


### PR DESCRIPTION
Made a few changes to the Podcast & Items Object:

- Previously the methods weren't able to pull strings from text within CDATA markup, specifically within the 'description' tags, so I updated the methods to do this & strip out any HTML markup within the strings

- I added an 'atom link' attribute which stores the rss feed link on the Podcast object

- I added 'itunes_season' and 'itunes_episode' attributes on the Item objects

Also updated all related testing